### PR TITLE
feat: pagination support and code quality improvements

### DIFF
--- a/app/controllers/incident_controller.py
+++ b/app/controllers/incident_controller.py
@@ -39,11 +39,16 @@ def add_incident_update_controller(data: IncidentUpdateEntry, current_user):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-def get_all_incidents_controller(org_id):
+def get_all_incidents_controller(org_id, page: int = 1, page_size: int = 20):
     try:
+        result = incident_service.get_incidents_by_org(org_id, page, page_size)
         return {
             "message": "Fetched all incidents successfully",
-            "incidents": incident_service.get_incidents_by_org(org_id),
+            "incidents": result["items"],
+            "total": result["total"],
+            "page": result["page"],
+            "page_size": result["page_size"],
+            "total_pages": result["total_pages"],
         }
     except Exception as e:
         raise HTTPException(
@@ -52,11 +57,16 @@ def get_all_incidents_controller(org_id):
         )
 
 
-def get_active_incidents_controller(org_id: int) -> list[IncidentOutFull]:
+def get_active_incidents_controller(org_id: int, page: int = 1, page_size: int = 20):
     try:
+        result = incident_service.get_active_incidents(org_id, page, page_size)
         return {
             "message": "Fetched all incidents successfully",
-            "incidents": incident_service.get_active_incidents(org_id),
+            "incidents": result["items"],
+            "total": result["total"],
+            "page": result["page"],
+            "page_size": result["page_size"],
+            "total_pages": result["total_pages"],
         }
     except Exception as e:
         raise HTTPException(

--- a/app/controllers/metrics_controller.py
+++ b/app/controllers/metrics_controller.py
@@ -24,7 +24,7 @@ def get_overall_uptime_metric_controller(org_id: int):
         )
 
 
-def get_complete_mtreric_controller(org_id: int):
+def get_complete_metric_controller(org_id: int):
     try:
         return {
             "overall_uptime_90d": compute_overall_uptime(org_id),

--- a/app/controllers/service_controller.py
+++ b/app/controllers/service_controller.py
@@ -44,5 +44,5 @@ def update_service_status_controller(
     return ServiceOut.from_orm(updated)
 
 
-def get_services_controller(org_id):
-    return service_service.get_services_by_org(org_id)
+def get_services_controller(org_id, page: int = 1, page_size: int = 20):
+    return service_service.get_services_by_org(org_id, page, page_size)

--- a/app/routes/incident_routes.py
+++ b/app/routes/incident_routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Query
 
 from app.controllers import incident_controller
 from app.models.users import Users
@@ -38,12 +38,20 @@ def add_incident_update(
 
 
 @router.get("/")
-def get_incidents(request: Request):
+def get_incidents(
+    request: Request,
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(20, ge=1, le=100, description="Items per page")
+):
     org_id = request.state.org_id
-    return incident_controller.get_all_incidents_controller(org_id)
+    return incident_controller.get_all_incidents_controller(org_id, page, page_size)
 
 
 @router.get("/active")
-def get_active_incidents(request: Request):
+def get_active_incidents(
+    request: Request,
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(20, ge=1, le=100, description="Items per page")
+):
     org_id = request.state.org_id
-    return incident_controller.get_active_incidents_controller(org_id)
+    return incident_controller.get_active_incidents_controller(org_id, page, page_size)

--- a/app/routes/metrics_router.py
+++ b/app/routes/metrics_router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Request
 from fastapi_cache.decorator import cache
 
 from app.controllers.metrics_controller import (
-    get_complete_mtreric_controller,
+    get_complete_metric_controller,
     get_overall_uptime_metric_controller,
     get_service_uptime_metrics_controller,
 )
@@ -26,4 +26,4 @@ def get_overall_uptime_route(request: Request):
 @cache(expire=1800)  # cache for 30 minutes
 def get_complete_metrics(request: Request):
     org_id = request.state.org_id
-    return get_complete_mtreric_controller(org_id)
+    return get_complete_metric_controller(org_id)

--- a/app/routes/service_routes.py
+++ b/app/routes/service_routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Query
 
 from app.controllers import service_controller
 from app.models.users import Users
@@ -35,7 +35,11 @@ def update_service_status(
     )
 
 
-@router.get("/", response_model=list[ServiceOut])
-def get_services(request: Request):
+@router.get("/")
+def get_services(
+    request: Request,
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(20, ge=1, le=100, description="Items per page")
+):
     org_id = request.state.org_id
-    return service_controller.get_services_controller(org_id)
+    return service_controller.get_services_controller(org_id, page, page_size)

--- a/app/schemas/pagination.py
+++ b/app/schemas/pagination.py
@@ -1,0 +1,20 @@
+from typing import Generic, TypeVar, List
+from pydantic import BaseModel
+
+T = TypeVar('T')
+
+
+class PaginationParams(BaseModel):
+    page: int = 1
+    page_size: int = 20
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: List[T]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+
+    class Config:
+        from_attributes = True

--- a/app/services/service_service.py
+++ b/app/services/service_service.py
@@ -159,6 +159,16 @@ def update_service_status_entry(service_id: int, new_status_code: int, user: Use
         raise RuntimeError(f"Service update failed: {str(e)}") from e
 
 
-def get_services_by_org(org_id: int):
+def get_services_by_org(org_id: int, page: int = 1, page_size: int = 20):
     with db_session() as db:
-        return db.query(Services).filter_by(org_id=org_id, is_deleted=False).all()
+        query = db.query(Services).filter_by(org_id=org_id, is_deleted=False)
+        total = query.count()
+        offset = (page - 1) * page_size
+        items = query.offset(offset).limit(page_size).all()
+        return {
+            "items": items,
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": (total + page_size - 1) // page_size
+        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,92 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.database import Base, get_db
+from main import app
+
+
+# Create an in-memory SQLite database for testing
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(scope="function")
+def db_session():
+    """Create a new database session for each test."""
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="function")
+def client(db_session):
+    """Create a test client with the test database."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def sample_organization(db_session):
+    """Create a sample organization for testing."""
+    from app.models.organizations import Organizations
+    org = Organizations(name="Test Organization", slug="test-org")
+    db_session.add(org)
+    db_session.commit()
+    db_session.refresh(org)
+    return org
+
+
+@pytest.fixture
+def sample_user(db_session, sample_organization):
+    """Create a sample admin user for testing."""
+    from app.models.users import Users
+    from app.utils.auth_util import get_password_hash
+
+    user = Users(
+        username="testadmin",
+        password=get_password_hash("testpassword"),
+        org_id=sample_organization.id,
+        role="admin"
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_token(sample_user):
+    """Generate an auth token for the sample user."""
+    from app.utils.auth_util import create_access_token
+    token = create_access_token(data={"sub": sample_user.username})
+    return token
+
+
+@pytest.fixture
+def auth_headers(auth_token, sample_organization):
+    """Return headers with authentication token and org."""
+    return {
+        "Authorization": f"Bearer {auth_token}",
+        "X-Org-Slug": sample_organization.slug
+    }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,114 @@
+import pytest
+
+
+class TestServiceEndpoints:
+    """Test cases for service endpoints."""
+
+    def test_get_services_empty(self, client, auth_headers):
+        """Test getting services when none exist."""
+        response = client.get("/services", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+        assert data["items"] == []
+        assert data["total"] == 0
+
+    def test_get_services_with_pagination(self, client, auth_headers):
+        """Test pagination parameters."""
+        response = client.get("/services?page=1&page_size=10", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert "page" in data
+        assert "page_size" in data
+        assert "total_pages" in data
+        assert data["page"] == 1
+        assert data["page_size"] == 10
+
+    def test_create_service(self, client, auth_headers):
+        """Test creating a new service."""
+        service_data = {
+            "service_name": "Test Service",
+            "status_code": 1
+        }
+        response = client.post("/services", json=service_data, headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["service_name"] == "Test Service"
+        assert data["status_code"] == 1
+
+    def test_create_service_missing_fields(self, client, auth_headers):
+        """Test creating a service with missing required fields."""
+        service_data = {"service_name": "Test Service"}
+        response = client.post("/services", json=service_data, headers=auth_headers)
+        assert response.status_code == 422  # Validation error
+
+    def test_update_service_status(self, client, auth_headers, db_session):
+        """Test updating a service status."""
+        # First create a service
+        from app.models.services import Services
+        service = Services(
+            service_name="Test Service",
+            status_code=1,
+            org_id=1
+        )
+        db_session.add(service)
+        db_session.commit()
+        db_session.refresh(service)
+
+        # Update status
+        response = client.patch(
+            f"/services/{service.id}/status",
+            json={"status_code": 2},
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+
+    def test_delete_service(self, client, auth_headers, db_session):
+        """Test deleting a service."""
+        from app.models.services import Services
+        service = Services(
+            service_name="Test Service",
+            status_code=1,
+            org_id=1
+        )
+        db_session.add(service)
+        db_session.commit()
+        db_session.refresh(service)
+
+        response = client.delete(f"/services/{service.id}", headers=auth_headers)
+        assert response.status_code == 204
+
+    def test_delete_nonexistent_service(self, client, auth_headers):
+        """Test deleting a service that doesn't exist."""
+        response = client.delete("/services/99999", headers=auth_headers)
+        assert response.status_code == 404
+
+
+class TestServicePagination:
+    """Test pagination functionality."""
+
+    def test_pagination_defaults(self, client, auth_headers):
+        """Test default pagination values."""
+        response = client.get("/services", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["page"] == 1
+        assert data["page_size"] == 20
+
+    def test_pagination_custom_values(self, client, auth_headers):
+        """Test custom pagination values."""
+        response = client.get("/services?page=2&page_size=5", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["page"] == 2
+        assert data["page_size"] == 5
+
+    def test_pagination_invalid_page(self, client, auth_headers):
+        """Test invalid page number."""
+        response = client.get("/services?page=0", headers=auth_headers)
+        assert response.status_code == 422  # Validation error for page < 1
+
+    def test_pagination_max_page_size(self, client, auth_headers):
+        """Test page size exceeding maximum."""
+        response = client.get("/services?page_size=200", headers=auth_headers)
+        assert response.status_code == 422  # Validation error for page_size > 100


### PR DESCRIPTION
## Summary
- Fixed typo: `mtreric` → `metric` in metrics router and controller
- Added pagination support to services and incidents endpoints:
  - GET /services now accepts `page` and `page_size` query params
  - GET /incidents now accepts `page` and `page_size` query params
  - GET /incidents/active now accepts `page` and `page_size` query params
- Created PaginatedResponse schema for consistent pagination responses
- Set up pytest testing infrastructure with SQLite test database
- Added service endpoint tests

## Test plan
- [ ] Run `pytest tests/` to verify test setup
- [ ] Test pagination: `GET /services?page=1&page_size=10`
- [ ] Test pagination: `GET /incidents?page=1&page_size=10`
- [ ] Verify response includes `items`, `total`, `page`, `page_size`, `total_pages`